### PR TITLE
Add startup message before long read and sort op

### DIFF
--- a/restore_ports/restore_ports.tcl
+++ b/restore_ports/restore_ports.tcl
@@ -291,6 +291,7 @@ if {[llength $::argv] == 0} {
 } else {
     set filename [lindex $::argv 0]
 }
+ui_msg "Reading and sorting port list from $filename ..."
 set portList [read_portlist $filename]
 #ui_msg "portlist = $portList"
 


### PR DESCRIPTION
The script pauses for a scary few seconds at the start, when it reads and sorts the port list. For a portliest of 750 entries, this takes a bit more time than is comfortable. This change prints a simple startup message before the pause. This should reassure the user that the script is running and not hung or crashed.